### PR TITLE
changed requests to prevent data read into memory

### DIFF
--- a/check_deck_price.py
+++ b/check_deck_price.py
@@ -5,6 +5,7 @@ import time
 import os
 
 def main(deck_filename):
+    script_location = os.path.dirname(os.path.realpath(__file__))
     # open the deck file
     with open(deck_filename, "r") as deck_file:
         deck = deck_file.read().splitlines()
@@ -15,7 +16,7 @@ def main(deck_filename):
     requested_days = days
 
     # we want to search for the db that is closest to the requested days
-    files = os.listdir("./card_db")
+    files = os.listdir(f"{script_location}/card_db")
     db_found = False
     while db_found == False:
         date = time.strftime("%Y%m%d", time.localtime(time.time() - (days * 86400)))
@@ -40,7 +41,7 @@ def main(deck_filename):
 
     def get_price(requested_db):
         total_price = 0
-        db = sqlite3.connect(f"./card_db/{requested_db}")
+        db = sqlite3.connect(f"{script_location}/card_db/{requested_db}")
         for card in deck:
             card_count = card.split(" ")[0]
             card_name = " ".join(card.split(" ")[1:-1]).split(" (")[0]

--- a/check_deck_price.py
+++ b/check_deck_price.py
@@ -35,7 +35,7 @@ def main(deck_filename):
         days -= 1
         if db_found == True:
             break
-        if days == 0:
+        if days == -1:
             print("No db found for that many days back!")
             sys.exit()
 

--- a/get_bulk_data.py
+++ b/get_bulk_data.py
@@ -1,23 +1,39 @@
-import requests
-import json
+import ijson
 import sqlite3
-
-
+import shutil
+import os
+import requests
 
 def get_bulk_data(download_url, timestamp):
-    data = requests.get(download_url).json()
-    conn = sqlite3.connect(f"./card_db/all-cards-{timestamp}.db")
-    c = conn.cursor()
-    # we want the card name, language, set, collector number, usd, usd_foil, usd_etched
-    c.execute('''CREATE TABLE cards (name text, lang text, set_code text, collector_number text, usd real, usd_foil real, usd_etched real)''')
-    for card in data:
-        name = card["name"]
-        lang = card["lang"]
-        set_code = card["set"]
-        collector_number = card["collector_number"]
-        usd = card["prices"]["usd"]
-        usd_foil = card["prices"]["usd_foil"]
-        usd_etched = card["prices"]["usd_etched"]
-        c.execute("INSERT INTO cards VALUES (?, ?, ?, ?, ?, ?, ?)", (name, lang, set_code, collector_number, usd, usd_foil, usd_etched))
-    conn.commit()
-    conn.close()
+    # create a tmp dir
+    tmp_dir = './tmp'
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+
+    dst = f'./tmp/all-cards-{timestamp}.json'
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36'}
+    r = requests.get(download_url, stream=True, headers=headers)
+    if r.status_code == 200:
+        with open(dst, 'wb') as f:
+            r.raw.decode_content = True
+            shutil.copyfileobj(r.raw, f)
+
+    with open(f'./tmp/all-cards-{timestamp}.json', 'r') as f:
+        objects = ijson.items(f, 'item')
+        db = sqlite3.connect(f'./card_db/all-cards-{timestamp}.db')
+        cursor = db.cursor()
+        cursor.execute('''CREATE TABLE IF NOT EXISTS cards (name text, lang text, set_code text, collector_number text, usd real, usd_foil real, usd_etched real)''')
+        for obj in objects:
+            # insert into database
+            name = obj["name"]
+            lang = obj["lang"]
+            set_code = obj["set"]
+            collector_number = obj["collector_number"]
+            usd = obj["prices"]["usd"]
+            usd_foil = obj["prices"]["usd_foil"]
+            usd_etched = obj["prices"]["usd_etched"]
+            cursor.execute("INSERT INTO cards VALUES (?, ?, ?, ?, ?, ?, ?)", (name, lang, set_code, collector_number, usd, usd_foil, usd_etched))
+        db.commit()
+        db.close()
+    # delete the tmp dir and all of its contents
+    shutil.rmtree(tmp_dir)

--- a/get_bulk_data.py
+++ b/get_bulk_data.py
@@ -5,12 +5,15 @@ import os
 import requests
 
 def get_bulk_data(download_url, timestamp):
+    # get script location
+    script_location = os.path.dirname(os.path.realpath(__file__))
+
     # create a tmp dir
-    tmp_dir = './tmp'
+    tmp_dir = f'.{script_location}/tmp'
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
 
-    dst = f'./tmp/all-cards-{timestamp}.json'
+    dst = f'.{script_location}/tmp/all-cards-{timestamp}.json'
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36'}
     r = requests.get(download_url, stream=True, headers=headers)
     if r.status_code == 200:
@@ -18,9 +21,9 @@ def get_bulk_data(download_url, timestamp):
             r.raw.decode_content = True
             shutil.copyfileobj(r.raw, f)
 
-    with open(f'./tmp/all-cards-{timestamp}.json', 'r') as f:
+    with open(f'.{script_location}/tmp/all-cards-{timestamp}.json', 'r') as f:
         objects = ijson.items(f, 'item')
-        db = sqlite3.connect(f'./card_db/all-cards-{timestamp}.db')
+        db = sqlite3.connect(f'.{script_location}/card_db/all-cards-{timestamp}.db')
         cursor = db.cursor()
         cursor.execute('''CREATE TABLE IF NOT EXISTS cards (name text, lang text, set_code text, collector_number text, usd real, usd_foil real, usd_etched real)''')
         for obj in objects:

--- a/get_bulk_data.py
+++ b/get_bulk_data.py
@@ -9,11 +9,11 @@ def get_bulk_data(download_url, timestamp):
     script_location = os.path.dirname(os.path.realpath(__file__))
 
     # create a tmp dir
-    tmp_dir = f'.{script_location}/tmp'
+    tmp_dir = f'{script_location}/tmp'
     if not os.path.exists(tmp_dir):
         os.makedirs(tmp_dir)
 
-    dst = f'.{script_location}/tmp/all-cards-{timestamp}.json'
+    dst = f'{script_location}/tmp/all-cards-{timestamp}.json'
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36'}
     r = requests.get(download_url, stream=True, headers=headers)
     if r.status_code == 200:
@@ -21,9 +21,9 @@ def get_bulk_data(download_url, timestamp):
             r.raw.decode_content = True
             shutil.copyfileobj(r.raw, f)
 
-    with open(f'.{script_location}/tmp/all-cards-{timestamp}.json', 'r') as f:
+    with open(f'{script_location}/tmp/all-cards-{timestamp}.json', 'r') as f:
         objects = ijson.items(f, 'item')
-        db = sqlite3.connect(f'.{script_location}/card_db/all-cards-{timestamp}.db')
+        db = sqlite3.connect(f'{script_location}/card_db/all-cards-{timestamp}.db')
         cursor = db.cursor()
         cursor.execute('''CREATE TABLE IF NOT EXISTS cards (name text, lang text, set_code text, collector_number text, usd real, usd_foil real, usd_etched real)''')
         for obj in objects:

--- a/ping_bulk_data.py
+++ b/ping_bulk_data.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         
         script_location = os.path.dirname(os.path.realpath(__file__))
         
-        if os.path.exists(f".{script_location}/card_db/all-cards-{timestamp}.db"):
+        if os.path.exists(f"{script_location}/card_db/all-cards-{timestamp}.db"):
             print("File already exists")
             # wait 10 minutes
             time.sleep(600)

--- a/ping_bulk_data.py
+++ b/ping_bulk_data.py
@@ -10,13 +10,13 @@ if __name__ == "__main__":
         bulk_data_links = requests.get("https://api.scryfall.com/bulk-data").json()
         all_cards_download_link = bulk_data_links["data"][3]["download_uri"]
         timestamp = str(all_cards_download_link).split("-")[-1].split(".")[0]
-        #print(timestamp)
-        if os.path.exists(f"./card_db/all-cards-{timestamp}.db"):
+        
+        script_location = os.path.dirname(os.path.realpath(__file__))
+        
+        if os.path.exists(f".{script_location}/card_db/all-cards-{timestamp}.db"):
             print("File already exists")
             # wait 10 minutes
             time.sleep(600)
         else:
             print("Create a new db save")
             get_bulk_data(all_cards_download_link, timestamp)
-
-    #get_bulk_data(all_cards_download_link)


### PR DESCRIPTION
Changed get_bulk_data.py's method of receiving data. Previously, all card objects in bulk-data file were being loaded into system memory. This caused my server to crash. To prevent this we can use request's raw content streaming by downloading the file as proposed #1 